### PR TITLE
[multiACE] Fix install persistence on firmware 1.4 (PAXX) + correct o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,9 +385,12 @@ Before installing multiACE, ensure the following:
 
 If you prefer manual installation:
 
-1. Copy Klipper extras to the printer:
+1. Copy Klipper extras to the printer (`ace.py` imports `ace_protocol*`, so all three must be copied or Klipper fails on import):
    ```
    cp klipper/extras/ace.py /home/lava/klipper/klippy/extras/
+   cp klipper/extras/ace_protocol.py /home/lava/klipper/klippy/extras/
+   cp klipper/extras/ace_protocol_v1.py /home/lava/klipper/klippy/extras/
+   cp klipper/extras/ace_protocol_v2.py /home/lava/klipper/klippy/extras/
    cp klipper/extras/filament_feed_ace.py /home/lava/klipper/klippy/extras/
    cp klipper/extras/filament_switch_sensor_ace.py /home/lava/klipper/klippy/extras/
    cp klipper/kinematics/extruder_ace.py /home/lava/klipper/klippy/kinematics/

--- a/multiace/README.md
+++ b/multiace/README.md
@@ -189,7 +189,11 @@ Before installing multiACE, ensure the following:
    touch /home/lava/.oem_debug
    ```
    After reboot, Wi-Fi password needs to be re-entered on the display. SSH is then available at `root@<printer-ip>`
-4. **Verify SSH** - Connect from your computer:
+4. **Enable persistence (firmware 1.4+ / PAXX)** - On firmware 1.4 and newer the root filesystem is an overlay that is reset to stock on **every reboot** unless `/oem/.debug` exists. Without it the installed multiACE plugin is wiped on the next power-cycle and Klipper fails to start with `Section 'ace' is not a valid config section`. Create the flag once - it lives on the persistent `/oem` partition and is **not** the same as the SSH flag `/home/lava/.oem_debug` (which is itself inside the wiped overlay):
+   ```
+   touch /oem/.debug
+   ```
+5. **Verify SSH** - Connect from your computer:
    ```
    ssh root@<printer-ip>
    ```
@@ -212,9 +216,12 @@ Before installing multiACE, ensure the following:
 
 If you prefer manual installation:
 
-1. Copy Klipper extras to the printer:
+1. Copy Klipper extras to the printer (`ace.py` imports `ace_protocol*`, so all three must be copied or Klipper fails on import):
    ```
    cp klipper/extras/ace.py /home/lava/klipper/klippy/extras/
+   cp klipper/extras/ace_protocol.py /home/lava/klipper/klippy/extras/
+   cp klipper/extras/ace_protocol_v1.py /home/lava/klipper/klippy/extras/
+   cp klipper/extras/ace_protocol_v2.py /home/lava/klipper/klippy/extras/
    cp klipper/extras/filament_feed_ace.py /home/lava/klipper/klippy/extras/
    cp klipper/extras/filament_switch_sensor_ace.py /home/lava/klipper/klippy/extras/
    cp klipper/kinematics/extruder_ace.py /home/lava/klipper/klippy/kinematics/

--- a/multiace/README_DE.md
+++ b/multiace/README_DE.md
@@ -189,7 +189,11 @@ Vor der Installation von multiACE sicherstellen:
    touch /home/lava/.oem_debug
    ```
    Nach dem Neustart muss das WLAN-Passwort am Display neu eingegeben werden. SSH ist dann unter `root@<drucker-ip>` erreichbar
-4. **SSH prüfen** - Vom Computer verbinden:
+4. **Persistenz aktivieren (Firmware 1.4+ / PAXX)** - Ab Firmware 1.4 ist das Root-Dateisystem ein Overlay, das bei **jedem Neustart** auf den Auslieferungszustand zurückgesetzt wird, sofern nicht die Datei `/oem/.debug` existiert. Ohne sie wird das installierte multiACE-Plugin beim nächsten Aus-/Einschalten gelöscht und Klipper startet nicht mehr (`Section 'ace' is not a valid config section`). Die Datei einmalig anlegen - sie liegt auf der persistenten `/oem`-Partition und ist **nicht** dasselbe wie das SSH-Flag `/home/lava/.oem_debug` (das selbst im gelöschten Overlay liegt):
+   ```
+   touch /oem/.debug
+   ```
+5. **SSH prüfen** - Vom Computer verbinden:
    ```
    ssh root@<drucker-ip>
    ```
@@ -212,9 +216,12 @@ Vor der Installation von multiACE sicherstellen:
 
 Für manuelle Installation:
 
-1. Klipper-Extras auf den Drucker kopieren:
+1. Klipper-Extras auf den Drucker kopieren (`ace.py` importiert `ace_protocol*`, daher müssen alle drei kopiert werden, sonst schlägt der Import in Klipper fehl):
    ```
    cp klipper/extras/ace.py /home/lava/klipper/klippy/extras/
+   cp klipper/extras/ace_protocol.py /home/lava/klipper/klippy/extras/
+   cp klipper/extras/ace_protocol_v1.py /home/lava/klipper/klippy/extras/
+   cp klipper/extras/ace_protocol_v2.py /home/lava/klipper/klippy/extras/
    cp klipper/extras/filament_feed_ace.py /home/lava/klipper/klippy/extras/
    cp klipper/extras/filament_switch_sensor_ace.py /home/lava/klipper/klippy/extras/
    cp klipper/kinematics/extruder_ace.py /home/lava/klipper/klippy/kinematics/

--- a/multiace/install_multiace.sh
+++ b/multiace/install_multiace.sh
@@ -66,6 +66,59 @@ for d in "$EXTRAS_DIR" "$KINEMATICS_DIR" "$CONFIG_DIR"; do
     fi
 done
 log "Target directories verified"
+# --------------------------------------------------------------------------
+# Persistence pre-check  (PAXX / Snapmaker firmware >= 1.4, overlayfs rootfs)
+#
+# On these firmwares "/" is an overlayfs whose writable upper layer is reset on
+# EVERY boot by /etc/init.d/S01aoverlayfs, UNLESS the marker file /oem/.debug
+# exists:
+#
+#     # /etc/init.d/S01aoverlayfs
+#     if [ ! -f /oem/.debug ]; then
+#         rm -rf /oem/overlay/*        # <- wipes /home/lava/klipper back to stock
+#     fi
+#
+# The multiACE Klipper plugin lives under /home/lava/klipper (inside the
+# overlay), so without /oem/.debug it is deleted on the next reboot - while the
+# config under /home/lava/printer_data (a separate, persistent partition)
+# survives. The printer then boots straight into:
+#
+#     ConfigError: Section 'ace' is not a valid config section
+#
+# This is exactly the "install verifies OK, then Klipper won't start after a
+# reboot" symptom. So: if this firmware uses that overlay-reset mechanism and
+# /oem/.debug is missing, abort BEFORE changing anything and tell the user how
+# to enable persistence. We deliberately do NOT create /oem/.debug
+# automatically - it turns off the firmware's boot-time overlay reset (a safety
+# feature), so enabling it must be an explicit, informed choice by the user.
+# --------------------------------------------------------------------------
+OVERLAY_INIT="/etc/init.d/S01aoverlayfs"
+if [ -f "$OVERLAY_INIT" ] && grep -q '/oem/\.debug' "$OVERLAY_INIT" 2>/dev/null; then
+    if [ ! -f /oem/.debug ]; then
+        log ""
+        log "============================================================"
+        log "  INSTALL ABORTED - PERSISTENCE NOT ENABLED"
+        log ""
+        log "  This firmware (PAXX / Snapmaker 1.4+) resets the Klipper"
+        log "  install to stock on EVERY reboot unless /oem/.debug exists."
+        log "  Installing now would appear to work, then Klipper would"
+        log "  fail to start after the next power-cycle with:"
+        log "      Section 'ace' is not a valid config section"
+        log ""
+        log "  Fix - enable persistence once, then re-run the installer:"
+        log ""
+        log "      touch /oem/.debug"
+        log "      bash $0 $*"
+        log ""
+        log "  /oem/.debug lives on the persistent /oem partition, so it"
+        log "  only needs to be created once. It disables the firmware's"
+        log "  boot-time overlay wipe so changes under /home/lava survive."
+        log "============================================================"
+        log ""
+        exit 1
+    fi
+    log "Persistence flag /oem/.debug present - overlay changes will survive reboot"
+fi
 log "Backing up current files..."
 for f in "filament_feed.py" "filament_switch_sensor.py"; do
     if [ -f "$EXTRAS_DIR/$f" ] && [ ! -f "$EXTRAS_DIR/${f%.py}_pre_multiace.py" ]; then


### PR DESCRIPTION
…ut-of-date manual-install docs — refs #31

Goal: run multiACE on PAXX 1.4.0 and, since there are no pre-compiled builds for it, install the plugin manually per the README. The install kept dying after a reboot with "Section 'ace' is not a valid config section", so we troubleshot it end-to-end on a Snapmaker U1 / PAXX 1.4.0.246 and found two problems: a firmware-persistence trap the installer didn't guard against, and stale manual-install docs.

Root cause (persistence): on firmware 1.4+ "/" is an overlayfs whose writable upper layer is wiped on EVERY boot by /etc/init.d/S01aoverlayfs (rm -rf /oem/overlay/*) unless the marker file /oem/.debug exists. The plugin lives under /home/lava/klipper (inside the overlay) so it is deleted on the next reboot, while the config under /home/lava/printer_data (a separate persistent partition) survives — hence the orphaned [ace] section and the crash. The installer made this worse by verifying files right after copy (they exist in the overlay) and reporting success, only for them to vanish at the next power-cycle. This is NOT a code-compat issue: 0.97.2b runs fine on 1.4 once it persists. Fix: install_multiace.sh now detects the overlay-reset mechanism (S01aoverlayfs guarded on /oem/.debug) and, when /oem/.debug is missing, aborts BEFORE touching anything with explicit instructions to `touch /oem/.debug` and re-run. We deliberately don't create the flag automatically — it disables a firmware safety feature, so it must be an informed user action. Backward compatible: skipped on firmwares without that init script.

Docs: the "Manual Install" step in README.md, multiace/README.md and the German multiace/README_DE.md omitted ace_protocol.py / ace_protocol_v1.py / ace_protocol_v2.py from the extras copy — ace.py imports them, so a literal manual install crashed on import. Added all three to the copy step (EN + DE), and added an "Enable persistence (firmware 1.4+ / PAXX)" prerequisite covering `touch /oem/.debug` and how it differs from the SSH flag /home/lava/.oem_debug.

Tested on Snapmaker U1 / PAXX 1.4.0.246: with /oem/.debug set + the corrected steps, the plugin and the web UI survive a full power-cycle and multiACE auto-loads with both ACE units connected.

Refs #31