### PR TITLE
ace.py: restore main_state=PRINTING after a head swap (fixes #35)

### DIFF
--- a/multiace/klipper/extras/ace.py
+++ b/multiace/klipper/extras/ace.py
@@ -5176,6 +5176,26 @@ class MultiAce:
                 'context': fa_prev_context,
             })
 
+            # Issue #35: a head swap walks the Snapmaker state machine to IDLE and
+            # never restores PRINTING, which blocks resume-after-pause and silently
+            # disables defect/spaghetti detection (it only runs while main_state is
+            # PRINTING). Restore PRINTING when mid-print. Wrapped so a state-manager
+            # hiccup can never disrupt the swap's own cleanup.
+            try:
+                msm = self.printer.lookup_object('machine_state_manager', None)
+                ps = self.printer.lookup_object('print_stats', None)
+                if msm is not None and ps is not None:
+                    et = self.printer.get_reactor().monotonic()
+                    in_print = ps.get_status(et).get('state') in ('printing', 'paused')
+                    if in_print and msm.get_status(et).get('main_state') == 0:
+                        self.gcode.run_script_from_command(
+                            'SET_MAIN_STATE MAIN_STATE=PRINTING ACTION=IDLE')
+                        logging.info(
+                            '[multiACE] #35: restored main_state=PRINTING after swap')
+            except Exception:
+                logging.exception(
+                    '[multiACE] #35: main_state restore after swap failed')
+
     def _switch_ace_for_head_target(self, ace_index):
         if ace_index == self._active_device_index:
             self._audit_state('SWITCH_TARGET_NOOP', {


### PR DESCRIPTION
A multiACE head swap walks the Snapmaker state machine PRINTING -> AUTO_UNLOAD -> IDLE -> AUTO_LOAD -> IDLE and never restores PRINTING. That leaves the print unresumable (pause_resume.py rejects RESUME with "Cannot resume while machine main_state: IDLE or action_code: IDLE") and silently disables defect/spaghetti detection (it only runs while main_state == PRINTING) - even though position, heaters and steppers are all intact.

Restore main_state to PRINTING at the end of cmd_ACE_SWAP_HEAD's finally block, guarded to only fire mid-print on main_state == IDLE (the verified-allowed IDLE -> PRINTING transition) and wrapped in try/except so it can never disrupt the swap's own cleanup. lookup_object(..., None) makes it a no-op on stock (non-Snapmaker) Klipper.

Validated on Snapmaker U1 / PAXX 1.4.0.246 / multiACE 0.97.3b: fires on a real mid-print ACE swap (logs "#35: restored main_state=PRINTING after swap"), restoring PRINTING so RESUME works again.

Fixes #35